### PR TITLE
Develop

### DIFF
--- a/src/main/scala/concurrency/FuturesPromisesFinal.scala
+++ b/src/main/scala/concurrency/FuturesPromisesFinal.scala
@@ -1,7 +1,8 @@
 package concurrency
 
+
 import scala.concurrent.{Future, Promise}
-import scala.util.{Failure, Success, Try}
+import scala.util.{Failure, Random, Success, Try}
 import scala.concurrent.ExecutionContext.Implicits.global
 
 /**
@@ -10,6 +11,42 @@ import scala.concurrent.ExecutionContext.Implicits.global
   *
   * - Futures, Part 4 + Exercises
   *
+  *   Back to the Future[T]
+  *   Future[T] is a computation which will finish at some point
+  *
+  *   {
+  *     import ExecutionContext.Implicits.global
+  *     val recipesFuture: Future[List[Recipe]] = Future {
+  *       // some code that takes a long time to run
+  *       jamieOliverDB.getAll("chicken")
+  *    }
+  *
+  *   Futures are immutable, "read-only" objects.
+  *   Promises are "Writable-once" containers over a future.
+  *   thread 1:
+  *   * create an empty promise
+  *   * knows how to handle the result
+  *   {
+  *     val p = Promise[Int]()
+  *     val future = p.future
+  *     future.onComplete {
+  *       case Success(value) =>
+  *       case Failure(ex) =>
+  *     }
+  *   }
+  *   promise wraps future
+  *   future is "undefined"
+  *   thread 2:
+  *   * holds the promise
+  *   * fulfills or fails the promise
+  *   {
+  *     val result = doComputation()
+  *     p.success(result)
+  *     or
+  *     p.failure(new BadException(...))
+  *     or
+  *     p.complete(Try{...})
+  *   }
   */
 object FuturesPromisesFinal extends App {
 
@@ -29,62 +66,119 @@ object FuturesPromisesFinal extends App {
     first.flatMap(_ => second)
 
   // 3 - first out of two futures
-  {
-    def first[A](fa: Future[A], fb: Future[A]): Future[A] = {
-      val promise = Promise[A]
-      fa.onComplete {
-        case Success(r) => try {
-          promise.success(r)
-        } catch {
-          case _ =>
-        }
-        case Failure(t) => try {
-          promise.failure(t)
-        } catch {
-          case _ =>
-        }
+  def first[A](fa: Future[A], fb: Future[A]): Future[A] = {
+    val promise = Promise[A]
+    fa.onComplete {
+      case Success(r) => try {
+        promise.success(r)
+      } catch {
+        case _ =>
       }
-      fb.onComplete {
-        case Success(r) => try {
-          promise.success(r)
-        } catch {
-          case _ =>
-        }
-        case Failure(t) => try {
-          promise.failure(t)
-        } catch {
-          case _ =>
-        }
+      case Failure(t) => try {
+        promise.failure(t)
+      } catch {
+        case _ =>
       }
-      promise.future
+    }
+    fb.onComplete {
+      case Success(r) => try {
+        promise.success(r)
+      } catch {
+        case _ =>
+      }
+      case Failure(t) => try {
+        promise.failure(t)
+      } catch {
+        case _ =>
+      }
+    }
+    promise.future
+  }
+
+  def firstRefactor[A](fa: Future[A], fb: Future[A]): Future[A] = {
+    val promise = Promise[A]
+
+    def tryComplete(promise: Promise[A], result: Try[A]) = result match {
+      case Success(r) => try {
+        promise.success(r)
+      } catch {
+        case _ =>
+      }
+      case Failure(t) => try {
+        promise.failure(t)
+      } catch {
+        case _ =>
+      }
     }
 
-    def firstRefactor[A](fa: Future[A], fb: Future[A]): Future[A] = {
-      val promise = Promise[A]
-
-      def tryComplete(promise: Promise[A], result: Try[A]) = result match {
-        case Success(r) => try {
-          promise.success(r)
-        } catch {
-          case _ =>
-        }
-        case Failure(t) => try {
-          promise.failure(t)
-        } catch {
-          case _ =>
-        }
-      }
-
-      fa.onComplete(tryComplete(promise, _))
-      fb.onComplete(tryComplete(promise, _))
-      promise.future
+    fa.onComplete(result => tryComplete(promise, result))
+    fb.onComplete(tryComplete(promise, _))
+    promise.future
     }
 
     def firstRefactorUsePromiseTryComplete[A](fa: Future[A], fb: Future[A]): Future[A] = {
       val promise = Promise[A]
       fa.onComplete(promise.tryComplete(_))
-      fb.onComplete(promise.tryComplete(_))
+      fb.onComplete(promise.tryComplete)
       promise.future
     }
+
+  // 4 - last out of the two futures
+
+  def last[A](fa: Future[A], fb: Future[A]): Future[A] = {
+    // 1 promise which both futures will try to complete
+    // 2 promise which the LAST future will complete
+    val bothPromise = Promise[A]
+    val lastPromise = Promise[A]
+    val checkAndComplete = (result: Try[A]) =>
+      if(!bothPromise.tryComplete(result))
+        lastPromise.complete(result)
+    /*
+    fa.onComplete(result => {
+      if (!bothPromise.tryComplete(result))
+        lastPromise.complete(result)
+    })
+    fb.onComplete(result => {
+      if (!bothPromise.tryComplete(result))
+        lastPromise.complete(result)
+    })
+    */
+    fa.onComplete(checkAndComplete)
+    fa.onComplete(checkAndComplete)
+
+    lastPromise.future
+  }
+
+  val fast = Future {
+    Thread.sleep(100)
+    42
+  }
+  val slow = Future {
+    Thread.sleep(200)
+    45
+  }
+  first(fast, slow).foreach(f => println("FIRST: " + f))
+  last(fast, slow).foreach(l => println("LAST: " + l))
+
+  Thread.sleep(1000)
+
+  // retry until
+  {
+    def retryUntil[A](action: () => Future[A], condition: A => Boolean): Future[A] =
+      action()
+        .filter(condition)
+        .recoverWith {
+          case _ => retryUntil(action, condition)
+        }
+
+    val random = new Random()
+    val action = () => Future {
+      Thread.sleep(100)
+      val nextValue = random.nextInt(100)
+      println("generated " + nextValue)
+      nextValue
+    }
+    retryUntil(action, (x: Int) => x < 10).foreach(result => println("settled at " + result))
+    Thread.sleep(10000)
   }
 }

--- a/src/main/scala/concurrency/FuturesPromisesFinal.scala
+++ b/src/main/scala/concurrency/FuturesPromisesFinal.scala
@@ -1,0 +1,90 @@
+package concurrency
+
+import scala.concurrent.{Future, Promise}
+import scala.util.{Failure, Success, Try}
+import scala.concurrent.ExecutionContext.Implicits.global
+
+/**
+  * A Taste of Advanced Scala
+  * Functional Concurrent Programming
+  *
+  * - Futures, Part 4 + Exercises
+  *
+  */
+object FuturesPromisesFinal extends App {
+
+  /*
+    1) fulfill a future IMMEDIATELY with a value
+    2) inSequence(fa, fb)
+    3) first(fa, fb) => new future with the first value of the two futures
+    4) last(fa, fb) => new future with the last value
+    5) retryUntil[T](action: () => Future[T], condition: T=> Boolean): Future[T]
+   */
+
+  // 1 - fulfill immediately
+  def fulfillImmediately[T](value: T): Future[T] = Future(value)
+
+  // 2 - inSequence
+  def inSequence[A, B](first: Future[A], second: Future[B]): Future[B] =
+    first.flatMap(_ => second)
+
+  // 3 - first out of two futures
+  {
+    def first[A](fa: Future[A], fb: Future[A]): Future[A] = {
+      val promise = Promise[A]
+      fa.onComplete {
+        case Success(r) => try {
+          promise.success(r)
+        } catch {
+          case _ =>
+        }
+        case Failure(t) => try {
+          promise.failure(t)
+        } catch {
+          case _ =>
+        }
+      }
+      fb.onComplete {
+        case Success(r) => try {
+          promise.success(r)
+        } catch {
+          case _ =>
+        }
+        case Failure(t) => try {
+          promise.failure(t)
+        } catch {
+          case _ =>
+        }
+      }
+      promise.future
+    }
+
+    def firstRefactor[A](fa: Future[A], fb: Future[A]): Future[A] = {
+      val promise = Promise[A]
+
+      def tryComplete(promise: Promise[A], result: Try[A]) = result match {
+        case Success(r) => try {
+          promise.success(r)
+        } catch {
+          case _ =>
+        }
+        case Failure(t) => try {
+          promise.failure(t)
+        } catch {
+          case _ =>
+        }
+      }
+
+      fa.onComplete(tryComplete(promise, _))
+      fb.onComplete(tryComplete(promise, _))
+      promise.future
+    }
+
+    def firstRefactorUsePromiseTryComplete[A](fa: Future[A], fb: Future[A]): Future[A] = {
+      val promise = Promise[A]
+      fa.onComplete(promise.tryComplete(_))
+      fb.onComplete(promise.tryComplete(_))
+      promise.future
+    }
+  }
+}

--- a/src/main/scala/concurrency/ParallelUtils.scala
+++ b/src/main/scala/concurrency/ParallelUtils.scala
@@ -1,0 +1,104 @@
+package concurrency
+
+import java.util.concurrent.ForkJoinPool
+import java.util.concurrent.atomic.AtomicReference
+
+import scala.collection.parallel.{ForkJoinTaskSupport, Task, TaskSupport}
+import scala.collection.parallel.immutable.ParVector
+
+/**
+  * A Taste of Advanced Scala
+  * Functional Concurrent Programming
+  *
+  * - Scala & JVM Standard Parallel Libraries
+  *   - parallel collections (par, Par)
+  *     - Map-reduce model
+  *     - synchronization
+  *     - alternatives
+  *   - atomic ops and references
+  */
+object ParallelUtils extends App {
+
+  // 1 - parallel collections
+  /*
+    Seq
+    Vector
+    Array
+    Map - Hash, Trie
+    Set - Hash, Trie
+   */
+  val parList = List(1,2,3).par
+
+  val aParVector = ParVector[Int](1, 2, 3)
+
+  // benchmark
+  def measure[T](operation: => T): Long = {
+    val time = System.currentTimeMillis()
+    operation
+    System.currentTimeMillis() - time
+  }
+
+  // serial time: 42
+  val list = (1 to 1000000).toList
+  val serialTime = measure {
+    list.map(_ + 1)
+  }
+  println("serial time: " + serialTime)
+
+  // parallel time: 206
+  val parallelTime = measure {
+    list.par.map(_ + 1)
+  }
+  println("parallel time: " + parallelTime)
+
+  /*
+    Map-reduce model
+    - split the elements into chunks - Splitter
+    - operation
+    - recombine - Combiner
+   */
+  // map, flatMap, filter, foreach, reduce, fold
+
+  // fold, reduce with non-associative operators
+  println(List(1, 2, 3).reduce(_ + _))
+  println(List(1, 2, 3).par.reduce(_ + _))
+
+  // synchronization
+  var sum = 0
+  List(1, 2, 3).par.foreach(sum += _)
+  println(sum) // 6 // race conditions!
+
+  // configuring.
+  aParVector.tasksupport = new ForkJoinTaskSupport(new ForkJoinPool(2))
+
+  /*
+    alternatives
+    - ThreadPoolTaskSupport - deprecated
+    - ExecutionContextTaskSupport(EC)
+   */
+  aParVector.tasksupport = new TaskSupport {
+    override def execute[R, Tp](fjtask: Task[R, Tp]): () => R = ???
+
+    override def executeAndWaitResult[R, Tp](task: Task[R, Tp]): R = ???
+
+    override def parallelismLevel: Int = ???
+
+    override val environment: AnyRef = None
+  }
+
+  // 2 - atomic ops and references
+
+  val atomic = new AtomicReference[Int](2)
+  val atomicList = List(
+    atomic.get(), // thread-safe read
+    atomic.set(4), // thread-safe write
+    atomic.getAndSet(5), // thread safe combo
+    atomic.compareAndSet(38, 56), // if the value is 38, then set to 56
+    atomic.updateAndGet(_ + 1),
+    atomic.getAndUpdate(_ + 1),
+    atomic.accumulateAndGet(12, _ + _),
+    atomic.getAndAccumulate(12, _ + _),
+    atomic.get()
+  ).filter(_ != ())
+  atomicList.foreach(println)
+}


### PR DESCRIPTION
- Scala & JVM Standard Parallel Libraries
  - parallel collections (par, Par)
    - Map-reduce model
    - synchronization
    - alternatives
  - atomic ops and references


- Futures, Part 4 + Exercises

   Back to the Future[T]
   Future[T] is a computation which will finish at some point

   {
     import ExecutionContext.Implicits.global
     val recipesFuture: Future[List[Recipe]] = Future {
       // some code that takes a long time to run
       jamieOliverDB.getAll("chicken")
    }

   Futures are immutable, "read-only" objects.
   Promises are "Writable-once" containers over a future.
   thread 1:
   * create an empty promise
   * knows how to handle the result
   {
     val p = Promise[Int]()
     val future = p.future
     future.onComplete {
       case Success(value) =>
       case Failure(ex) =>
     }
   }
   promise wraps future
   future is "undefined"
   thread 2:
   * holds the promise
   * fulfills or fails the promise
   {
     val result = doComputation()
     p.success(result)
     or
     p.failure(new BadException(...))
     or
     p.complete(Try{...})
   }