### PR TITLE
Type Class part 3

### DIFF
--- a/src/main/scala/exercises/EqualityPlayground.scala
+++ b/src/main/scala/exercises/EqualityPlayground.scala
@@ -1,0 +1,49 @@
+package exercises
+
+import implicits.TypeClassesType2.{User}
+
+object EqualityPlayground {
+
+  /**
+    * Equality
+    */
+  // TYPE CLASS
+  trait Equal[T] {
+    def apply(a: T, b: T): Boolean
+  }
+  object Equal {
+    def apply[T](a: T, b: T)(implicit equalizer: Equal[T]): Boolean =
+      equalizer.apply(a, b)
+  }
+
+  implicit object NameEquality extends Equal[User] {
+    override def apply(a: User, b: User): Boolean = a.name == b.name
+  }
+  object FullEquality extends Equal[User] {
+    override def apply(a: User, b: User): Boolean = a.name == b.name && a.email == b.email
+  }
+
+  /*
+    Exercise - improve the Equal TC with an implicit conversion class
+    ===(another value: T)
+    !==(another value: T)
+   */
+  implicit class TypeSafeEqual[T](value :T) {
+    def ===(another: T)(implicit equalizer: Equal[T]): Boolean = equalizer.apply(value, another)
+    def !==(another: T)(implicit equalizer: Equal[T]): Boolean = ! equalizer.apply(value, another)
+  }
+
+  val john = User("Jon", 44, "jon@example.com")
+  val anotherJohn = User("Jon", 44, "jon@example.com")
+
+  println(john === anotherJohn)
+  /*
+    john.===(anotherJohn)
+    new TypeSafeEqual[User](john).===(anotherJohn)
+    new TypeSafeEqual[User](john).===(anotherJohn)(NameEquality)
+   */
+  /*
+    TYPE SAFE
+   */
+
+}

--- a/src/main/scala/implicits/MyTypeClassTemplate.scala
+++ b/src/main/scala/implicits/MyTypeClassTemplate.scala
@@ -1,0 +1,9 @@
+package implicits
+
+// TYPE CLASS
+trait MyTypeClassTemplate[T] {
+  def action(value: T): String
+}
+object MyTypeClassTemplate {
+  def apply[T](implicit instance: MyTypeClassTemplate[T]) = instance
+}


### PR DESCRIPTION
- very difficulty

```scala
  def htmlBoilerplate[T](content: T)(implicit serializer: HTMLSerializer[T]): String =
    s"<html><body> ${content.toHTML(serializer)} </body></html>"

  def htmlSugar[T : HTMLSerializer](content: T): String = {
     val serializer = implicitly[HTMLSerializer[T]]
     // use serializer
     s"<html><body> ${content.toHTML(serializer)}</body></html>"
   }

  // implicitly
  case class Permissions(mask: String)
  implicit val defaultPermissions: Permissions = Permissions("0744")

  // in some other part of the code
  val standardPerms = implicitly[Permissions](defaultPermissions)
```

* test code
```scala
    println(2.toHTML)
    println(john.toHTML(PartialUserSerializer))

    println(htmlBoilerplate(john)(HTMLSerializer[User]))
    println(htmlSugar(john))
```