### PR TITLE
Develop

### DIFF
--- a/src/main/scala/implicits/MagnetPattern.scala
+++ b/src/main/scala/implicits/MagnetPattern.scala
@@ -1,0 +1,166 @@
+package implicits
+
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
+
+/**
+  * A Taste of Advanced Scala
+  * AdvancedFunctional Programing
+  *
+  * - A Type Class Use Case / The Magnet Pattern
+  *   {{{
+  *     trait HandleMagnet {
+  *       def apply(): Unit
+  *     }
+  *     def handle(magnet: HandleMagnet) = magnet()
+  *
+  *     implicit class StringHandle(s: => String) extends HandleMagnet {
+  *     override def apply(): Unit = {
+  *       println(s)
+  *       println(s)
+  *     }
+  *   }
+  *
+  *   def sideEffectMethod(): String = {
+  *     println("Hello Scala")
+  *     "hahaha"
+  *   }
+  *   handle(sideEffectMethod()) // =>
+  *   handle {
+  *     println("Hello, Scala")
+  *     "magnet"
+  *   }
+  *   }}}
+  */
+object MagnetPattern extends App {
+
+  // MagnetPattern is method overloading
+  class P2PRequest
+  class P2PResponse
+  class Serializer[T]
+  trait Actor {
+    def receive(statusCode: Int): Int
+    def receive(request: P2PRequest): Int
+    def receive(response: P2PResponse): Int
+    def receive[T : Serializer](message: T): Int
+    def receive[T : Serializer](message: T, statusCode: Int): Int
+    def receive(future: Future[P2PRequest])
+    // def receive(future: Future[P2PResponse]): Int => Generics type compile error
+    // lots of overloads
+  }
+
+  /* Troubles
+    1 - type erasure
+    2 - lifting doesn't work for all overloads
+
+      val receiveFV = receive _ // ?!
+
+    3 - code duplication
+    4 - type interrence and default args
+
+      actor.receive(?!)
+   */
+
+  // Magnet Pattern (Type Parameter) 🔴
+  trait MessageMagnet[Result] {
+    def apply(): Result
+  }
+
+  def receive[R](magnet: MessageMagnet[R]): R = magnet.apply()
+
+  implicit class FromP2PRequest(request: P2PRequest) extends MessageMagnet[Int] {
+    def apply(): Int = {
+      // logic for handling a P2P request
+      println("Handling P2P request")
+      42
+    }
+  }
+  implicit class FromP2PResponse(response: P2PResponse) extends MessageMagnet[Int] {
+    def apply(): Int = {
+      // logic for handling a P2P response
+      println("Handling P2P response")
+      24
+    }
+  }
+  // call a Magnet Pattern
+  val test1 = {
+    receive(new P2PRequest)
+    receive(new P2PResponse)
+  }
+
+  // 1 - no more type erasure problems!
+  implicit class FromResponseFuture(future: Future[P2PResponse]) extends MessageMagnet[Int] {
+    def apply(): Int = 2
+  }
+  implicit class FromRequestFuture(future: Future[P2PRequest]) extends MessageMagnet[Int] {
+    def apply(): Int = 3
+  }
+
+  val test2 = {
+    println(receive(Future(new P2PRequest)))
+    println(receive(Future(new P2PResponse)))
+  }
+
+  // 2 - lifting works
+  trait MathLib {
+    def add1(x: Int) = x + 1
+    def add1(x: String) = x.toInt + 1
+  }
+  // "magnetize"
+  trait AddMagnet {
+    def apply(): Int // concrete not Type Parameter 🔴
+  }
+  def add1(magnet: AddMagnet): Int = magnet()
+
+  implicit class AddInt(x: Int) extends AddMagnet {
+    override def apply(): Int = x + 1
+  }
+  implicit class AddString(s: String) extends AddMagnet {
+    override def apply(): Int = s.toInt + 1
+  }
+
+  val test3 = {
+    val addFV = add1 _
+    println(addFV(1))
+    println(addFV("3"))
+    val receiveFV = receive _ // => MessageMagnet[Noting]
+  }
+
+  /*
+    Drawbacks
+    1 - verbose
+    2 - harder to read
+    3 - you can't name or place default arguments
+    4 - call by name  doesn't work correctly
+    (exercise: prove it!) (hint; side effects
+   */
+  class Hander {
+    def handle(s: => String): Unit = {
+      println(s)
+      println(s)
+    }
+  }
+  trait HandleMagnet {
+    def apply(): Unit
+  }
+  def handle(magnet: HandleMagnet) = magnet()
+
+  implicit class StringHandle(s: => String) extends HandleMagnet {
+    override def apply(): Unit = {
+      println(s)
+      println(s)
+    }
+  }
+
+  def sideEffectMethod(): String = {
+    println("Hello Scala")
+    "hahaha"
+  }
+  handle(sideEffectMethod()) // =>
+  handle {
+    println("Hello, Scala")
+    "magnet"
+  }
+
+
+}

--- a/src/main/scala/implicits/ScalaJavaConversions.scala
+++ b/src/main/scala/implicits/ScalaJavaConversions.scala
@@ -1,0 +1,62 @@
+package implicits
+
+import java.{util => ju}
+
+/**
+  * A Taste of Advanced Scala
+  * AdvancedFunctional Programing
+  *
+  * - Scala <> Java conversions
+  *   - collection.JavaConverters._
+  */
+object ScalaJavaConversions extends App {
+
+  import collection.JavaConverters._
+
+  val javaSet: ju.Set[Int] = new ju.HashSet[Int]()
+
+  val test1 = {
+    1 to 5 foreach javaSet.add
+    println(javaSet)
+  }
+
+  val scalaSet = javaSet.asScala
+
+  /*
+  　Iterator
+    Iterable
+    ju.List - scala.mutable.Buffer
+    ju.Set - scala.mutable.Set
+    ju.Map - scala.mutable.Map
+   */
+  import collection.mutable._
+  val numbersBuffer = ArrayBuffer[Int](1, 2, 3)
+  val juNumbersBuffer = numbersBuffer.asJava
+
+  val numbers = List(1, 2, 3)
+  val juNumbers = numbers.asJava
+  val backToScala = juNumbers.asScala
+
+  val test2 = {
+    println(juNumbersBuffer.asScala eq numbersBuffer)
+    println(backToScala eq numbers) // false
+    println(backToScala == numbers) // true
+  }
+  /*
+    Exercise
+    create a Scala-Java Optional-Option
+        .asScala
+   */
+  class ToScala[T](value: => T) {
+    def asScala: T = value
+  }
+  implicit def asScalaOptional[T](o: ju.Optional[T]): ToScala[Option[T]] = new ToScala[Option[T]](
+    if (o.isPresent) Some(o.get) else None
+  )
+
+  val test3 ={
+    val juOptional: ju.Optional[Int] = ju.Optional.of(2)
+    val scalaOption = juOptional.asScala
+    println(scalaOption)
+  }
+}

--- a/src/main/scala/typesystem/RockingInheritance.scala
+++ b/src/main/scala/typesystem/RockingInheritance.scala
@@ -1,0 +1,85 @@
+package typesystem
+
+
+/**
+  * A Taste of Advanced Scala
+  * AdvancedFunctional Programing
+  *
+  * - Advanced Inheritance
+  */
+/*
+  Type linearization
+  Cold = AnyRef with <Cold>
+  Green
+    = Cold with <Green>
+    = AnyRef with <Cold> with <Green>
+  Blue
+    = Cold with <Blue>
+    = AnyRef with <Cold> with <Blue> with <Green>
+  Red = AnyRef with <Red>
+ */
+object RockingInheritance extends App{
+
+  // convenience
+  trait Writer[T] {
+    def write(value: T): Unit
+  }
+  trait Closeable{
+    def close(status: Int): Unit
+  }
+  trait GenericsStream[T] {
+    def foreach(f: T => Unit): Unit
+  }
+  def processStream[T](stream: GenericsStream[T] with Writer[T] with Closeable): Unit = {
+    stream.foreach(println)
+    stream.close(0)
+  }
+
+  // diamond problem
+  trait Animal { def name: String }
+  trait Lion extends Animal {
+    override def name: String = "lion"}
+  trait Tiger extends Animal {
+    override def name: String = "tiger" }
+  class Mutant extends Lion with Tiger
+
+  val m = new Mutant
+  println(m.name) // => "tiger"
+
+  /*
+    Mutant
+    extends Animal with {override def name: String = "lion" }
+    with {override def name: String = "tiger}
+
+    LAST OVERRIDE GETS PICKED 🔴
+   */
+
+  // the super problem + type linearization
+  trait Cold {
+    def print = println("cold")
+  }
+  trait Green extends Cold {
+    override def print: Unit = {
+      println("green")
+      super.print
+    }
+  }
+  trait Blue extends Cold {
+    override def print: Unit = {
+      println("blue")
+      super.print
+    }
+  }
+  class Red {
+    def print = println("red")
+  }
+
+  class White extends Red with Cold with Green with Blue {
+    override def print: Unit = {
+      println("write")
+      super.print
+    }
+  }
+
+  println(new White().print) // write => blue => green => cold //
+}


### PR DESCRIPTION
# Scala <> Java conversions

- collection.JavaConverters._

# A Type Class Use Case / The Magnet Pattern

  {{{
    trait HandleMagnet {
      def apply(): Unit
    }
    def handle(magnet: HandleMagnet) = magnet()

    implicit class StringHandle(s: => String) extends HandleMagnet {
    override def apply(): Unit = {
      println(s)
      println(s)
    }
  }

  def sideEffectMethod(): String = {
    println("Hello Scala")
    "hahaha"
  }
  handle(sideEffectMethod()) // =>
  handle {
    println("Hello, Scala")
    "magnet"
  }
  }}}

# Advanced Inheritance

  Type linearization
  Cold = AnyRef with <Cold>
  Green
    = Cold with <Green>
    = AnyRef with <Cold> with <Green>
  Blue
    = Cold with <Blue>
    = AnyRef with <Cold> with <Blue> with <Green>
  Red = AnyRef with <Red>