### PR TITLE
PathDependentTypes

### DIFF
--- a/src/main/scala/typesystem/InvariantCovariantContravariant.scala
+++ b/src/main/scala/typesystem/InvariantCovariantContravariant.scala
@@ -2,7 +2,7 @@ package typesystem
 
  /**
    * A Taste of Advanced Scala
-   * AdvancedFunctional Programing
+   * Mastering the Type System
    *
    *  - Advanced Inheritance
    *  1. Invariant, covariant, contravariant

--- a/src/main/scala/typesystem/PathDependentTypes.scala
+++ b/src/main/scala/typesystem/PathDependentTypes.scala
@@ -1,0 +1,76 @@
+  package typesystem
+
+/**
+  * A Taste of Advanced Scala
+  * Mastering the Type System
+  *
+  *  - Inner Types and Path-Dependent Types
+  *  {{{
+  *  trait ItemLike {
+  *     type Key
+  *   }
+  *   trait Item[K] extends ItemLike {
+  *     type Key = K
+  *   }
+  *   trait IntItem extends Item[Int]
+  *   trait StringItem extends Item[String]
+  *
+  *  def get[ItemType <: ItemLike](key: ItemType#Key): ItemType = ???
+  *  }}}
+  */
+object PathDependentTypes extends App {
+
+  class Outer {
+    class Inner
+    object InnerObject
+    type InnerType
+
+    def print(i: Inner) = println(i)
+    def printGeneral(i: Outer#Inner) = println(i)
+  }
+
+  def aMethod: Int= {
+    class HelperClass
+    type HelperType = String
+    2
+  }
+
+  // per-instance
+  val o = new Outer
+  val inner = new o.Inner // o.Inner is a Type
+
+  val oo = new Outer
+  // val otherInner: oo.Inner = new o.Inner
+
+  o.print(inner)
+
+  // path-dependent types
+
+  // Outer#Inner
+  o.printGeneral(inner)
+  oo.printGeneral(inner)
+
+  /*
+    Exercise
+    DB keyed by Int or String, but maybe others
+   */
+  /*
+    use path-dependent types
+    abstract type members and/or type aliases
+   */
+  trait ItemLike {
+    type Key
+  }
+  trait Item[K] extends ItemLike {
+    type Key = K
+  }
+  trait IntItem extends Item[Int]
+  trait StringItem extends Item[String]
+
+  def get[ItemType <: ItemLike](key: ItemType#Key): ItemType = ???
+
+  get[IntItem](42) // ok
+
+  get[StringItem]("scala") // ok
+
+}

--- a/src/main/scala/typesystem/RockingInheritance.scala
+++ b/src/main/scala/typesystem/RockingInheritance.scala
@@ -3,7 +3,7 @@ package typesystem
 
 /**
   * A Taste of Advanced Scala
-  * AdvancedFunctional Programing
+  * Mastering the Type System
   *
   * - Advanced Inheritance
   */

--- a/src/main/scala/typesystem/StructuralTypes.scala
+++ b/src/main/scala/typesystem/StructuralTypes.scala
@@ -1,0 +1,112 @@
+package typesystem
+
+/**
+  * A Taste of Advanced Scala
+  * Mastering the Type System
+  *
+  * - Structural Types and Compile-Time Duck Typing
+  */
+object StructuralTypes extends App {
+
+  // structural types
+  type JavaCloseable = java.io.Closeable
+  class HipsterCloseable {
+    def close() = println("yeah yeah I'm closing")
+    def closeSilently(): Unit = println("not make sounds")
+  }
+
+  // def closeQuietly(closeable: JavaCloseable OR HipsterCloseable) // ?!
+  type UnifiedCloseable = {
+    def close(): Unit
+  } // STRUCTURAL TYPE
+  def closeQuietly(unifiedCloseable: UnifiedCloseable): Unit = unifiedCloseable.close()
+
+  closeQuietly(new JavaCloseable {
+    override def close(): Unit = ???
+  })
+  closeQuietly(new HipsterCloseable)
+
+
+  // TYPE REFINEMENTS java Closeable + closeSilently
+  type AdvancedCloseable = JavaCloseable {
+    def closeSilently(): Unit
+  }
+  class AdvancedJavaCloseable extends JavaCloseable {
+    override def close(): Unit = println("Java closes")
+    def closeSilently(): Unit = println("Java closes silently") // 🔴
+  }
+
+  def closeShh(advCloseable: AdvancedCloseable): Unit = advCloseable.closeSilently()
+
+  closeShh(new AdvancedJavaCloseable)
+  // closeShh(new HipsterCloseable) => compile error
+
+  // using structural types as standalone types
+  // oun type
+  def altClose(closeable: {def close(): Unit}): Unit = closeable.close()
+
+  // type-checking => dock typing
+  type SoundMaker = {
+    def makeSound(): Unit
+  }
+
+  class Dog {
+    def makeSound(): Unit = println("bark!")
+  }
+  class Car {
+    def makeSound(): Unit = println("yroooom!")
+  }
+
+  // static duck typing
+  val doc: SoundMaker = new Dog // runtime structure type use reflection
+  val car: SoundMaker = new Car
+
+  // CAVEAT: based on reflection
+
+  /*
+    Exercises
+   */
+  // 1.
+  trait CBL[+T] {
+    def head: T
+    def tail: CBL[T]
+  }
+
+  class Human {
+    def head: Brain = new Brain
+  }
+  class Brain {
+    override def toString: String = "BRAINZ!"
+  }
+
+  def f[T](somethingWithAHead: {def head: T}): Unit = println(somethingWithAHead.head)
+
+  /*
+    f is compatible with a CBL and with a Human? yes.
+   */
+
+  case object CBNil extends CBL[Nothing] {
+    def head: Nothing = ???
+    def tail: CBL[Nothing] = ???
+  }
+  case class CBCons[T](override val head: T, override val tail: CBL[T]) extends CBL[T]
+
+  f(CBCons(2, CBNil))
+  f(new Human) // ?! T = Brain !!
+
+  // 2.
+  object HeadEqualizer {
+    type Headable[T] = { def head: T }
+    def ===[T](a: Headable[T], b: Headable[T]): Boolean = a.head == b.head
+  }
+
+  /*
+    is compatible with a CBL and with a Human? Yes.
+   */
+  val brainzList = CBCons(new Brain, CBNil)
+  val stringsList = CBCons("Brainz", CBNil)
+
+  HeadEqualizer.==(brainzList, new Human)
+
+  HeadEqualizer.==(new Human, stringsList) // not type safe
+}

--- a/src/main/scala/typesystem/TypeMembers.scala
+++ b/src/main/scala/typesystem/TypeMembers.scala
@@ -2,7 +2,7 @@
 
 /**
   * A Taste of Advanced Scala
-  * AdvancedFunctional Programing
+  * Mastering the Type System
   *
   * - Type Members
   *   {{{

--- a/src/main/scala/typesystem/Variance.scala
+++ b/src/main/scala/typesystem/Variance.scala
@@ -2,7 +2,7 @@ package typesystem
 
 /**
   * A Taste of Advanced Scala
-  * AdvancedFunctional Programing
+  * Mastering the Type System
   *
   * - Variance
   *   Big rule


### PR DESCRIPTION
- Inner Types and Path-Dependent Types
trait ItemLike {
   type Key
 }
 trait Item[K] extends ItemLike {
   type Key = K
 }
 trait IntItem extends Item[Int]
 trait StringItem extends Item[String]

def get[ItemType <: ItemLike](key: ItemType#Key): ItemType = ???